### PR TITLE
rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,29 @@
+Lint/UnusedMethodArgument:
+    AllowUnusedKeywordArguments: true
+
+Metrics/LineLength:
+    Max: 150
+Metrics/ClassLength:
+    Max: 500
+Metrics/MethodLength:
+    Max: 100
+Metrics/AbcSize:
+    Max: 50
+
+Performance/Casecmp:
+    Enabled: false
+
+Style/PreferredHashMethods:
+    EnforcedStyle: verbose
+Style/MultilineMethodCallIndentation:
+    EnforcedStyle: indented
+Style/Documentation:
+    Enabled: false
+Style/FrozenStringLiteralComment:
+    Enabled: false
+Style/ClassAndModuleChildren:
+    Enabled: false
+Style/BracesAroundHashParameters:
+    Enabled: false
+Style/WordArray:
+    Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
 
 sudo: required
+dist: trusty
 
 install: true
 
 services:
-    - docker
+  - docker
 
 script:
   - docker build . -t operationcode/operationcode_bot:latest

--- a/Gemfile
+++ b/Gemfile
@@ -9,15 +9,15 @@ gem 'operationcode-airtable', git: 'https://github.com/OperationCode/operationco
 gem 'operationcode-slack', git: 'https://github.com/OperationCode/operationcode-slack'
 gem 'pry'
 gem 'rake'
-gem 'rubocop'
 gem 'rb-readline'
+gem 'rubocop'
 gem 'sinatra'
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0.0'
   gem 'minitest'
   gem 'minitest-reporters'
-  gem 'rack-test'
   gem 'mocha'
+  gem 'rack-test'
   gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,10 @@ gem 'rb-readline'
 gem 'sinatra'
 
 group :test do
-  gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rack-test'
   gem 'mocha'
-  gem "simplecov"
+  gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'operationcode-airtable', git: 'https://github.com/OperationCode/operationco
 gem 'operationcode-slack', git: 'https://github.com/OperationCode/operationcode-slack'
 gem 'pry'
 gem 'rake'
+gem 'rubocop'
 gem 'rb-readline'
 gem 'sinatra'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     airtable (0.0.9)
       httparty
     ansi (1.5.0)
+    ast (2.3.0)
     builder (3.2.3)
     codeclimate-test-reporter (1.0.5)
       simplecov
@@ -46,6 +47,9 @@ GEM
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     multi_xml (0.6.0)
+    parser (2.3.3.1)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -55,8 +59,15 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rainbow (2.2.1)
     rake (12.0.0)
     rb-readline (0.5.3)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     simplecov (0.13.0)
       docile (~> 1.1.0)
@@ -72,6 +83,7 @@ GEM
     tilt (2.0.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (1.1.3)
 
 PLATFORMS
   ruby
@@ -90,6 +102,7 @@ DEPENDENCIES
   rack-test
   rake
   rb-readline
+  rubocop
   simplecov
   sinatra
 
@@ -97,4 +110,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See ```Event::TeamJoin``` as a reference.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/OperationCode/operation_code_bot. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/OperationCode/operationcode_bot. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/lib/button_press/greeted.rb
+++ b/lib/button_press/greeted.rb
@@ -7,4 +7,3 @@ class ButtonPress::Greeted < ButtonPress
     @response = updated_message.to_json
   end
 end
-

--- a/lib/event.rb
+++ b/lib/event.rb
@@ -1,6 +1,6 @@
 # Base class for events
 class Event
-  STAFF_NOTIFICATION_CHANNEL = 'G3NDEBB45'
+  STAFF_NOTIFICATION_CHANNEL = 'G3NDEBB45'.freeze
 
   def initialize(data, token: nil, logger: nil)
     @data = data

--- a/lib/event/message.rb
+++ b/lib/event/message.rb
@@ -19,7 +19,11 @@ class Event
     end
 
     def process
-      im = Operationcode::Slack::Im.new(user: user.id, channel: @channel, text: "I'm sorry. I don't know how to talk to humans yet. Here's what I do know.")
+      im = Operationcode::Slack::Im.new(
+        user: user.id,
+        channel: @channel,
+        text: "I'm sorry. I don't know how to talk to humans yet. Here's what I do know."
+      )
       im.make_interactive_with!(HelpMenu.generate_interactive_message)
       im.deliver
     end

--- a/lib/event/message.rb
+++ b/lib/event/message.rb
@@ -51,17 +51,15 @@ class Event
 
     def invite_user_to(squad)
       channel_id = Squad.channel_id_for squad
-
       log "Inviting #{user.id} (#{user.name}) to channel #{channel_id} (#{squad})"
-      if ENV['INVITE_USER'] == 'true'
-        Operationcode::Slack::Api::ChannelsInvite.post(
-          with_data: {
-            token: @token,
-            channel: channel_id,
-            user: user.id
-          }
-        )
-      end
+      return if ENV['INVITE_USER'] != 'true'
+      Operationcode::Slack::Api::ChannelsInvite.post(
+        with_data: {
+          token: @token,
+          channel: channel_id,
+          user: user.id
+        }
+      )
     end
 
     def save_user_to_airtables!

--- a/lib/event/message.rb
+++ b/lib/event/message.rb
@@ -8,7 +8,7 @@ class Event
   class Message < Event
     attr_reader :user
 
-    ACTIONABLE_KEYWORD = 'yes'
+    ACTIONABLE_KEYWORD = 'yes'.freeze
 
     def initialize(data, token: nil, logger: nil)
       @message = data['event']['text']

--- a/lib/event/message.rb
+++ b/lib/event/message.rb
@@ -66,7 +66,7 @@ class Event
 
     def save_user_to_airtables!
       log "Adding slack username #{user.name} to squad #{@squad} to airtables"
-      Airtables::MentorshipSquads.create({slack_username: user.name, squad: @squad})
+      Airtables::MentorshipSquads.create({ slack_username: user.name, squad: @squad })
     end
 
     def least_populated_squad

--- a/lib/event/team_join.rb
+++ b/lib/event/team_join.rb
@@ -42,7 +42,7 @@ class Event
           text: 'Have they been greeted?',
           id: 'greeted',
           actions: [
-            {name: 'yes', text: 'Yes', value: 'yes'}
+            { name: 'yes', text: 'Yes', value: 'yes' }
           ]
         )
       )

--- a/lib/help_menu.rb
+++ b/lib/help_menu.rb
@@ -14,13 +14,15 @@ class HelpMenu
     ERB.new(template).result(binding)
   end
 
-  private
+  class << self
+    private
 
-  def self.template_path
-    Pathname.new(__dir__) + '..' + 'views' + self.name.to_s.underscore + '..'
-  end
+    def template_path
+      Pathname.new(__dir__) + '..' + 'views' + name.to_s.underscore + '..'
+    end
 
-  def self.class_to_filename
-    "#{self.name.to_s.demodulize.underscore.downcase}_message.txt.erb"
+    def class_to_filename
+      "#{name.to_s.demodulize.underscore.downcase}_message.txt.erb"
+    end
   end
 end

--- a/operationcode_bot.rb
+++ b/operationcode_bot.rb
@@ -96,7 +96,7 @@ end
 def dispatch_event(type: event_type, with_data: data, token: nil)
   # This wierd Object include check has to do with Ruby's odd main/top level behaviours
   # We are basically just checking that the method was defined in this file
-  if(type && Object.private_instance_methods.include?(type.to_sym))
+  if type && Object.private_instance_methods.include?(type.to_sym)
     send(type.to_sym, with_data, token: token)
   else
     logger.info "Did not find a handler for event type '#{type}'"

--- a/rakefile
+++ b/rakefile
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
 Rake::TestTask.new do |t|
   require "simplecov"
@@ -12,7 +13,6 @@ Rake::TestTask.new do |t|
   ENV['INVITE_USER'] = 'true'
   ENV['SLACK_CHANNEL_1ST_SQUAD'] = '1STSQUADID'
 
-
   base_dir = File.expand_path(File.dirname(__FILE__))
   lib_dir  = File.join(base_dir, "lib")
   test_dir = File.join(base_dir, "test")
@@ -24,4 +24,8 @@ Rake::TestTask.new do |t|
   t.verbose = false
 end
 
-task default: :test
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
+
+task default: [:test, :rubocop]

--- a/test/lib/event/message_test.rb
+++ b/test/lib/event/message_test.rb
@@ -28,7 +28,7 @@ class Event::MessageTest < Minitest::Test
 
     HTTParty.expects(:post)
       .with('https://slack.com/api/channels.invite', body: { token: nil, user: 'FAKEUSERID', channel: '1STSQUADID' })
-      .returns({ok: true}.to_json)
+      .returns({ ok: true }.to_json)
 
     event = Event::Message.new(mock_message_event(with_text: 'yes'))
     event.process

--- a/test/lib/event/message_test.rb
+++ b/test/lib/event/message_test.rb
@@ -63,8 +63,8 @@ class Event::MessageTest < Minitest::Test
 
   def mock_message_event(with_text: 'MESSAGE TEXT')
     {
-      'token'=>'FAKETOKEN',
-      'team_id'=>'TEAMID',
+      'token' => 'FAKETOKEN',
+      'team_id' => 'TEAMID',
       'event' => {
         'type' => 'message',
         'user' => 'FAKEUSERID',

--- a/test/lib/event/team_join_test.rb
+++ b/test/lib/event/team_join_test.rb
@@ -17,7 +17,17 @@ class Event::TeamJoinTest < Minitest::Test
   end
 
   def test_it_sends_a_message_to_the_user_if_an_env_var_is_set
-    welcome_string = "Hi FAKE.USERNAME,\n\nWelcome to Operation Code! I'm a bot designed to help answer questions and get you on your\nway in our community.\n\nOur goal here at Operation Code is to get veterans and their families started on the path to\na career in programming. We do that through providing you with scholarships, mentoring, career\ndevelopment opportunities, conference tickets, and more!\n\nYou're currently in Slack, a chat application that serves as the hub of Operation Code.\nIf you're currently visiting us via your browser Slack provides a stand alone program\nto make staying in touch even more convenient. You can download it here:\nhttps://slack.com/downloads\n\nBelow you'll see a list of topics. You can click on each topic to get more info. If you\nwant to see the topics again just reply to me with any message.\n\nWant to make your first change to a program right now? Click on the 'OpCode Challenge'\nbutton to get instructions on how to make a change to this very bot!\n"
+    welcome_string = "Hi FAKE.USERNAME,\n\nWelcome to Operation Code! I'm a bot designed to help answer questions and get you on your\n" \
+      "way in our community.\n\nOur goal here at Operation Code is to get veterans and their families started on the path to\n" \
+      "a career in programming. We do that through providing you with scholarships, mentoring, career\n" \
+      "development opportunities, conference tickets, and more!\n\n" \
+      "You're currently in Slack, a chat application that serves as the hub of Operation Code.\n" \
+      "If you're currently visiting us via your browser Slack provides a stand alone program\n" \
+      "to make staying in touch even more convenient. You can download it here:\nhttps://slack.com/downloads\n\n" \
+      "Below you'll see a list of topics. You can click on each topic to get more info. If you\n" \
+      "want to see the topics again just reply to me with any message.\n\n" \
+      "Want to make your first change to a program right now? Click on the 'OpCode Challenge'\n" \
+      "button to get instructions on how to make a change to this very bot!\n".freeze
     ENV['PRODUCTION_MODE'] = 'true'
     assert_equal 'true', ENV['PRODUCTION_MODE']
     Operationcode::Slack::Im.expects(:new).with(user: 'FAKEUSERID', text: welcome_string).returns(@mock_im)

--- a/test/lib/event/team_join_test.rb
+++ b/test/lib/event/team_join_test.rb
@@ -56,8 +56,8 @@ class Event::TeamJoinTest < Minitest::Test
       'type' => 'team_join',
       'event' => {
         'user' => {
-          'id' =>'FAKEUSERID',
-          'name' =>'FAKE.USERNAME',
+          'id' => 'FAKEUSERID',
+          'name' => 'FAKE.USERNAME',
           'real_name' => 'FAKE NAME',
           'profile' => {
             'first_name' => 'FAKEFIRSTNAME',

--- a/test/lib/event/team_join_test.rb
+++ b/test/lib/event/team_join_test.rb
@@ -55,7 +55,7 @@ class Event::TeamJoinTest < Minitest::Test
       'token' => 'FAKETOKEN',
       'type' => 'team_join',
       'event' => {
-      'user' => {
+        'user' => {
           'id' =>'FAKEUSERID',
           'name' =>'FAKE.USERNAME',
           'real_name' => 'FAKE NAME',

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -19,7 +19,8 @@ class OperationcodeBotTest < Minitest::Test
   def test_it_responds_to_ping
     get '/ping'
     assert last_response.ok?
-    assert_equal ({ success: :ok, data: :pong }.to_json), last_response.body
+    expected = { success: :ok, data: :pong }.to_json
+    assert_equal expected, last_response.body
   end
 
   def test_it_can_oauth

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -117,8 +117,8 @@ class OperationcodeBotTest < Minitest::Test
     button_press_data = {
       'actions' => [{ 'name' => 'yes', 'value' => 'yes' }],
       'callback_id' => 'greeted',
-      'channel' => { 'id'=>'CHANNEL_ID', 'name'=>'privategroup' },
-      'user' => { 'id'=>'TEST_USER_ID', 'name'=>'TEST_USER_NAME' },
+      'channel' => { 'id' => 'CHANNEL_ID', 'name' => 'privategroup' },
+      'user' => { 'id' => 'TEST_USER_ID', 'name' => 'TEST_USER_NAME' },
       'action_ts' => '1000000000.000000',
       'message_ts' => '1999999999.999999',
       'attachment_id' => '1',

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -3,8 +3,8 @@ require_relative './test_helper'
 class OperationcodeBotTest < Minitest::Test
   include Rack::Test::Methods
 
-  SLACK_OAUTH_ACCESS_PATH = 'https://slack.com/api/oauth.access'
-  SLACK_USERS_INFO_PATH = 'https://slack.com/api/users.info'
+  SLACK_OAUTH_ACCESS_PATH = 'https://slack.com/api/oauth.access'.freeze
+  SLACK_USERS_INFO_PATH = 'https://slack.com/api/users.info'.freeze
 
   def app
     Sinatra::Application

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -101,7 +101,7 @@ class OperationcodeBotTest < Minitest::Test
         user: {
           id: 'FAKEUSERID',
           name: 'FAKEUSERNAME'
-        },
+        }
       },
       type: 'event_callback',
       authed_users: [

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -71,8 +71,24 @@ class OperationcodeBotTest < Minitest::Test
     mock_notification_im.expects(:make_interactive_with!)
 
     Operationcode::Slack::User.any_instance.stubs(:name).returns('FAKEUSERNAME')
-    Operationcode::Slack::Im.expects(:new).with(user: 'FAKEUSERID', text: "Hi FAKEUSERNAME,\n\nWelcome to Operation Code! I'm a bot designed to help answer questions and get you on your\nway in our community.\n\nOur goal here at Operation Code is to get veterans and their families started on the path to\na career in programming. We do that through providing you with scholarships, mentoring, career\ndevelopment opportunities, conference tickets, and more!\n\nYou're currently in Slack, a chat application that serves as the hub of Operation Code.\nIf you're currently visiting us via your browser Slack provides a stand alone program\nto make staying in touch even more convenient. You can download it here:\nhttps://slack.com/downloads\n\nBelow you'll see a list of topics. You can click on each topic to get more info. If you\nwant to see the topics again just reply to me with any message.\n\nWant to make your first change to a program right now? Click on the 'OpCode Challenge'\nbutton to get instructions on how to make a change to this very bot!\n").returns(mock_im)
-    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKEUSERNAME has joined the slack team :tada:').returns(mock_notification_im)
+    Operationcode::Slack::Im.expects(:new).with(
+      user: 'FAKEUSERID',
+      text: "Hi FAKEUSERNAME,\n\nWelcome to Operation Code! I'm a bot designed to help answer questions and get you on your\n" \
+        "way in our community.\n\nOur goal here at Operation Code is to get veterans and their families started on the path to\n" \
+        "a career in programming. We do that through providing you with scholarships, mentoring, career\n" \
+        "development opportunities, conference tickets, and more!\n\n" \
+        "You're currently in Slack, a chat application that serves as the hub of Operation Code.\n" \
+        "If you're currently visiting us via your browser Slack provides a stand alone program\n" \
+        "to make staying in touch even more convenient. You can download it here:\nhttps://slack.com/downloads\n\n" \
+        "Below you'll see a list of topics. You can click on each topic to get more info. If you\n" \
+        "want to see the topics again just reply to me with any message.\n\n" \
+        "Want to make your first change to a program right now? Click on the 'OpCode Challenge'\n" \
+        "button to get instructions on how to make a change to this very bot!\n"
+    ).returns(mock_im)
+    Operationcode::Slack::Im.expects(:new).with(
+      channel: 'G3NDEBB45',
+      text: ':tada: FAKEUSERNAME has joined the slack team :tada:'
+    ).returns(mock_notification_im)
 
     team_join_data = {
       token: 'FAKE_TOKEN',
@@ -128,7 +144,10 @@ class OperationcodeBotTest < Minitest::Test
       }
     }
 
-    button_press_response = "{\"text\":\":tada: TEST_USER has joined the slack team :tada:\",\"username\":\"operationcodebot\",\"bot_id\":\"TEST_BOT_ID\",\"attachments\":[{\"callback_id\":\"greeted\",\"fallback\":\"Have they been greeted?\",\"text\":\"\\u003c@TEST_USER_ID\\u003e has greeted the new user\",\"id\":1,\"color\":\"3AA3E3\",\"actions\":[]}],\"type\":\"message\",\"subtype\":\"bot_message\",\"ts\":\"1485611482.000040\"}"
+    button_press_response = '{"text":":tada: TEST_USER has joined the slack team :tada:","username":"operationcodebot",' \
+      '"bot_id":"TEST_BOT_ID","attachments":[{"callback_id":"greeted","fallback":"Have they been greeted?",' \
+      '"text":"\\u003c@TEST_USER_ID\\u003e has greeted the new user","id":1,"color":"3AA3E3","actions":[]}],"type":"message",' \
+      '"subtype":"bot_message","ts":"1485611482.000040"}'
 
     post '/slack/button_press', { 'payload' => button_press_data.to_json }
     assert_equal button_press_response, last_response.body

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -98,8 +98,8 @@ class OperationcodeBotTest < Minitest::Test
         type: 'team_join',
         event_ts: '1234567890.123456',
         user: {
-          id: "FAKEUSERID",
-          name: "FAKEUSERNAME"
+          id: 'FAKEUSERID',
+          name: 'FAKEUSERNAME'
         },
       },
       type: 'event_callback',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,14 @@
-require "simplecov"
+require 'simplecov'
 SimpleCov.start
 
 ENV['RACK_ENV'] = 'test'
 
 require 'operationcode_bot'
 require 'minitest/autorun'
-require "mocha/mini_test"
+require 'mocha/mini_test'
 require 'rack/test'
 
-require "minitest/reporters"
+require 'minitest/reporters'
 Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
 
 ENV['SLACK_TOKEN'] = 'test_token'


### PR DESCRIPTION
1. run rubocop in the default rake task so it runs as part of CI
1. fix a bunch of stuff, including an interesting bug: 435088a

I'm not super happy about Style/TrailingCommaInLiteral but you can read my musings in f0496d4

I'm also not happy about Style/RedundantParentheses because not having parens on function calls causes all sorts of ambiguous parsing (`some_func 1-2` vs `some_func 1 -2`) including in this very project, causing me to have to work around it (615ad09). That ship has long sailed, though

You can see what a faililng build looks like here: https://travis-ci.org/raylu/operationcode_bot/builds/199111596