### PR TITLE
Addresses #16, Bot specifies that new users should be DMed, not just greeted

### DIFF
--- a/lib/event/team_join.rb
+++ b/lib/event/team_join.rb
@@ -35,11 +35,11 @@ class Event
     def notify_staff!
       im = Operationcode::Slack::Im.new(
         channel: Event::STAFF_NOTIFICATION_CHANNEL,
-        text: ":tada: #{@user.name} has joined the slack team :tada:"
+        text: ":tada: #{@user.name} has joined the Slack team :tada:"
       )
       im.make_interactive_with!(
         Operationcode::Slack::Im::Interactive.new(
-          text: 'Have they been greeted?',
+          text: 'Have they been greeted via direct message?',
           id: 'greeted',
           actions: [
             {name: 'yes', text: 'Yes', value: 'yes'}


### PR DESCRIPTION
Clarifies that the user should direct-message the new member.