### PR TITLE
Addresses #16, Bot specifies that new users should be DMed, not just greeted

### DIFF
--- a/lib/event/team_join.rb
+++ b/lib/event/team_join.rb
@@ -35,11 +35,11 @@ class Event
     def notify_staff!
       im = Operationcode::Slack::Im.new(
         channel: Event::STAFF_NOTIFICATION_CHANNEL,
-        text: ":tada: #{@user.name} has joined the slack team :tada:"
+        text: ":tada: #{@user.name} has joined the Slack team :tada:"
       )
       im.make_interactive_with!(
         Operationcode::Slack::Im::Interactive.new(
-          text: 'Have they been greeted?',
+          text: 'Have they been greeted via direct message?',
           id: 'greeted',
           actions: [
             {name: 'yes', text: 'Yes', value: 'yes'}

--- a/test/lib/event/team_join_test.rb
+++ b/test/lib/event/team_join_test.rb
@@ -21,14 +21,14 @@ class Event::TeamJoinTest < Minitest::Test
     ENV['PRODUCTION_MODE'] = 'true'
     assert_equal 'true', ENV['PRODUCTION_MODE']
     Operationcode::Slack::Im.expects(:new).with(user: 'FAKEUSERID', text: welcome_string).returns(@mock_im)
-    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKE.USERNAME has joined the slack team :tada:').returns(@mock_im)
+    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKE.USERNAME has joined the Slack team :tada:').returns(@mock_im)
 
     Event::TeamJoin.new(mock_team_join_event).process
 
     ENV['PRODUCTION_MODE'] = 'false'
     assert_equal 'false', ENV['PRODUCTION_MODE']
     Operationcode::Slack::Im.expects(:new).with(user: 'U08U56D5K', text: welcome_string).returns(@mock_im)
-    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKE.USERNAME has joined the slack team :tada:').returns(@mock_im)
+    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKE.USERNAME has joined the Slack team :tada:').returns(@mock_im)
 
     Event::TeamJoin.new(mock_team_join_event).process
   end

--- a/test/operationcode_bot_test.rb
+++ b/test/operationcode_bot_test.rb
@@ -72,7 +72,7 @@ class OperationcodeBotTest < Minitest::Test
 
     Operationcode::Slack::User.any_instance.stubs(:name).returns('FAKEUSERNAME')
     Operationcode::Slack::Im.expects(:new).with(user: 'FAKEUSERID', text: "Hi FAKEUSERNAME,\n\nWelcome to Operation Code! I'm a bot designed to help answer questions and get you on your\nway in our community.\n\nOur goal here at Operation Code is to get veterans and their families started on the path to\na career in programming. We do that through providing you with scholarships, mentoring, career\ndevelopment opportunities, conference tickets, and more!\n\nYou're currently in Slack, a chat application that serves as the hub of Operation Code.\nIf you're currently visiting us via your browser Slack provides a stand alone program\nto make staying in touch even more convenient. You can download it here:\nhttps://slack.com/downloads\n\nBelow you'll see a list of topics. You can click on each topic to get more info. If you\nwant to see the topics again just reply to me with any message.\n\nWant to make your first change to a program right now? Click on the 'OpCode Challenge'\nbutton to get instructions on how to make a change to this very bot!\n").returns(mock_im)
-    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKEUSERNAME has joined the slack team :tada:').returns(mock_notification_im)
+    Operationcode::Slack::Im.expects(:new).with(channel: 'G3NDEBB45', text: ':tada: FAKEUSERNAME has joined the Slack team :tada:').returns(mock_notification_im)
 
     team_join_data = {
       token: 'FAKE_TOKEN',


### PR DESCRIPTION
Fixes test from #18 