### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See ```Event::TeamJoin``` as a reference.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/OperationCode/operation_code_bot. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/OperationCode/operationcode_bot. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 


### PR DESCRIPTION
```
https://github.com/OperationCode/operation_code_bot
>>
https://github.com/OperationCode/operationcode_bot
```