### PR TITLE
Update readme usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ Then you'll just need to add the messages template with $CLASS_NAME_message.txt.
 
 ### Adding A New Event
 
-To create a new event simply define a new method with the same name as the method you want to handle.
+To create a new event, within the [operationcode_bot.rb](https://github.com/OperationCode/operationcode_bot/blob/master/operationcode_bot.rb) file, simply define a new `private` method with the same name as the method you want to handle.
+
 For example, if you wanted to write some code any time someone [pins an item](https://api.slack.com/events/pin_added) (the ```pin_added``` event) you would define
 a new method like so:
 
 ```ruby
+private
+
 def pin_added(data, token: nil)
   logger.add "Got pin_added event with data: #{data}"
   empty_response

--- a/lib/event/message.rb
+++ b/lib/event/message.rb
@@ -4,69 +4,67 @@ require 'operationcode/slack'
 # * Be assigned to the least populated mentorship squad
 # * Have their squad and user info added to the Mentorship air table
 # * Be invited to the squad's slack private channel
-class Event
-  class Message < Event
-    attr_reader :user
+class Event::Message < Event
+  attr_reader :user
 
-    ACTIONABLE_KEYWORD = 'yes'
+  ACTIONABLE_KEYWORD = 'yes'
 
-    def initialize(data, token: nil, logger: nil)
-      @message = data['event']['text']
-      @user = Operationcode::Slack::User.new(data['event']['user'])
-      @channel = data['event']['channel']
+  def initialize(data, token: nil, logger: nil)
+    @message = data['event']['text']
+    @user = Operationcode::Slack::User.new(data['event']['user'])
+    @channel = data['event']['channel']
 
-      super
+    super
+  end
+
+  def process
+    im = Operationcode::Slack::Im.new(user: user.id, channel: @channel, text: "I'm sorry. I don't know how to talk to humans yet. Here's what I do know.")
+    im.make_interactive_with!(HelpMenu.generate_interactive_message)
+    im.deliver
+  end
+
+  private
+
+  # The rest of this has to do with actionable items
+  # and will be moved over soon
+  def user_wants_to_join?
+    @data['event']['text'].downcase != 'no'
+  end
+
+  def add_user
+    if user_exists?
+      log "user #{user.name} already exists"
+    else
+      invite_user_to least_populated_squad
+      save_user_to_airtables!
     end
+  end
 
-    def process
-      im = Operationcode::Slack::Im.new(user: user.id, channel: @channel, text: "I'm sorry. I don't know how to talk to humans yet. Here's what I do know.")
-      im.make_interactive_with!(HelpMenu.generate_interactive_message)
-      im.deliver
+  def user_exists?
+    Airtables::MentorshipSquads.user_exists?(user.name)
+  end
+
+  def invite_user_to(squad)
+    channel_id = Squad.channel_id_for squad
+
+    log "Inviting #{user.id} (#{user.name}) to channel #{channel_id} (#{squad})"
+    if ENV['INVITE_USER'] == 'true'
+      Operationcode::Slack::Api::ChannelsInvite.post(
+        with_data: {
+          token: @token,
+          channel: channel_id,
+          user: user.id
+        }
+      )
     end
+  end
 
-    private
+  def save_user_to_airtables!
+    log "Adding slack username #{user.name} to squad #{@squad} to airtables"
+    Airtables::MentorshipSquads.create({slack_username: user.name, squad: @squad})
+  end
 
-    # The rest of this has to do with actionable items
-    # and will be moved over soon
-    def user_wants_to_join?
-      @data['event']['text'].downcase != 'no'
-    end
-
-    def add_user
-      if user_exists?
-        log "user #{user.name} already exists"
-      else
-        invite_user_to least_populated_squad
-        save_user_to_airtables!
-      end
-    end
-
-    def user_exists?
-      Airtables::MentorshipSquads.user_exists?(user.name)
-    end
-
-    def invite_user_to(squad)
-      channel_id = Squad.channel_id_for squad
-
-      log "Inviting #{user.id} (#{user.name}) to channel #{channel_id} (#{squad})"
-      if ENV['INVITE_USER'] == 'true'
-        Operationcode::Slack::Api::ChannelsInvite.post(
-          with_data: {
-            token: @token,
-            channel: channel_id,
-            user: user.id
-          }
-        )
-      end
-    end
-
-    def save_user_to_airtables!
-      log "Adding slack username #{user.name} to squad #{@squad} to airtables"
-      Airtables::MentorshipSquads.create({slack_username: user.name, squad: @squad})
-    end
-
-    def least_populated_squad
-      @squad ||= Airtables::MentorshipSquads.least_populated
-    end
+  def least_populated_squad
+    @squad ||= Airtables::MentorshipSquads.least_populated
   end
 end

--- a/lib/event/team_join.rb
+++ b/lib/event/team_join.rb
@@ -6,51 +6,49 @@ require 'operationcode/slack'
 #   * Be assigned to the least populated mentorship squad
 #   * Have their squad and user info added to the Mentorship air table
 #   * Be invited to the squad's slack private channel
-class Event
-  class TeamJoin < Event
-    attr_reader :user
+class Event::TeamJoin < Event
+  attr_reader :user
 
-    def initialize(data, token: nil, logger: nil)
-      super
-      @template = File.read(template_path + 'welcome_message.txt.erb')
-    end
+  def initialize(data, token: nil, logger: nil)
+    super
+    @template = File.read(template_path + 'welcome_message.txt.erb')
+  end
 
-    def process
-      @user = Operationcode::Slack::User.new(@data['event']['user'])
-      log "Production mode: #{production_mode?}"
-      log "Welcoming user #{resolve_user_name}"
+  def process
+    @user = Operationcode::Slack::User.new(@data['event']['user'])
+    log "Production mode: #{production_mode?}"
+    log "Welcoming user #{resolve_user_name}"
 
-      welcome_user!
-      notify_community!
-    end
+    welcome_user!
+    notify_community!
+  end
 
-    private
+  private
 
-    def welcome_user!
-      im = Operationcode::Slack::Im.new(user: resolve_user_name, text: ERB.new(@template).result(binding))
-      im.make_interactive_with!(HelpMenu.generate_interactive_message)
-      im.deliver
-    end
+  def welcome_user!
+    im = Operationcode::Slack::Im.new(user: resolve_user_name, text: ERB.new(@template).result(binding))
+    im.make_interactive_with!(HelpMenu.generate_interactive_message)
+    im.deliver
+  end
 
-    def notify_community!
-      im = Operationcode::Slack::Im.new(
-        channel: Event::COMMUNITY_CHANNEL,
-        text: ":tada: <@#{user.id}> has joined the Slack team :tada:"
-        )
-      im.make_interactive_with!(
-        Operationcode::Slack::Im::Interactive.new(
-          text: 'Have they been greeted via direct message?',
-          id: 'greeted',
-          actions: [
-            {name: 'yes', text: 'Yes', value: 'yes'}
-          ]
-        )
+  def notify_community!
+    im = Operationcode::Slack::Im.new(
+      channel: Event::COMMUNITY_CHANNEL,
+      text: ":tada: <@#{user.id}> has joined the Slack team :tada:"
       )
-      im.deliver
-    end
+    im.make_interactive_with!(
+      Operationcode::Slack::Im::Interactive.new(
+        text: 'Have they been greeted via direct message?',
+        id: 'greeted',
+        actions: [
+          {name: 'yes', text: 'Yes', value: 'yes'}
+        ]
+      )
+    )
+    im.deliver
+  end
 
-    def resolve_user_name
-      production_mode? ? user.id : 'U08U56D5K'
-    end
+  def resolve_user_name
+    production_mode? ? user.id : 'U08U56D5K'
   end
 end


### PR DESCRIPTION
# Description of changes
When reading through the `README` and the codebase, it was unclear how our custom "adding a new event" hook would work.

After tracing through the code, it appears that you cannot just create a Slack "equally named" method anywhere.  That method would, in fact, have to live in the the `operationcode_bot.rb` file in order for the hook to work.

This update makes that more transparent for future contributors.

I also noticed that classes in the `event` directory are classes within classes.  This is not a typical way to namespace. 

Traditionally, when a class is in a folder for namespacing, you either nest the class in a module, or use this namespacing `::` syntax.

I refactored the two classes to use the `::` syntax.
